### PR TITLE
chore(home page): getting/generating a learning plan enhancement

### DIFF
--- a/app/api/generate-plan/route.ts
+++ b/app/api/generate-plan/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/app/lib/prisma";
 
 export async function POST(req: NextRequest) {
   try {
@@ -35,7 +36,17 @@ export async function POST(req: NextRequest) {
       }, { status: 500 });
     }
 
-    console.log("Making request to OpenRouter with topic:", topic);
+    const existingPlan = await prisma.learningPlan.findFirst({
+      where: {
+        topic,
+        user: { clerkId: userId }
+      }
+    });
+
+    if (existingPlan) {
+      console.log("Plan already exists in DB, returning cached version.");
+      return NextResponse.json({ plan: existingPlan.content, fromCache: true });
+    }
 
     // Add timeout to the fetch request
     const controller = new AbortController();
@@ -99,7 +110,7 @@ export async function POST(req: NextRequest) {
       }
       
       console.log("Plan validation passed, returning plan");
-      return NextResponse.json({ plan });
+      return NextResponse.json({ plan, fromCache: true });
     } catch (fetchError) {
       clearTimeout(timeoutId);
       if (fetchError instanceof Error && fetchError.name === 'AbortError') {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -106,8 +106,8 @@ function HomePageContent() {
 
       setPlan(topic, planContent);
 
-      // Only save if we have a valid plan and user is signed in
-      if (user && planContent && planContent.trim() !== "") {
+      // Only save if we have a valid plan, user is signed in and the data is not in cache (databases)
+      if (user && planContent && planContent.trim() !== "" && data.fromCache == false) {
         const saveRes = await fetch("/api/save-learning-plan", {
           method: "POST",
           headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
When we generate a plan, now it first check the cache. If the plan asked is in the cache, it doesnot regenerate it and doesnot save it again.
So it reduces the plan generation time and saves the create operation in the databases.